### PR TITLE
ErrorBound: compute in plain mode and then adjust by verified compensation

### DIFF
--- a/Global Optimization (New library)/src/ErrorBound.java
+++ b/Global Optimization (New library)/src/ErrorBound.java
@@ -1,0 +1,168 @@
+
+import net.java.jinterval.interval.set.SetInterval;
+import net.java.jinterval.interval.set.SetIntervalContext;
+import net.java.jinterval.interval.set.SetIntervalContexts;
+import net.java.jinterval.rational.BinaryValueSet;
+import net.java.jinterval.rational.ExtendedRational;
+import net.java.jinterval.rational.ExtendedRationalContext;
+import net.java.jinterval.rational.ExtendedRationalContexts;
+import net.java.jinterval.rational.Rational;
+
+/**
+ *
+ */
+public class ErrorBound {
+
+    private final Factory factory;
+    private final SetInterval range;
+    private final SetInterval err;
+
+    private static final ExtendedRationalContext exact = ExtendedRationalContexts.exact();
+    private static final Rational HALF = Rational.valueOf(0.5);
+    
+    public static class Factory {
+
+        private final ErrorBound[] origin;
+        private final SetIntervalContext ic; //This field determine accuracy of computing.
+        private final BinaryValueSet valueSet;
+
+        private Factory(SetIntervalContext ic, BinaryValueSet valueSet, SetInterval[] x) {
+            int dim = x.length;
+            origin = new ErrorBound[dim];
+            this.valueSet = valueSet;
+            for (int i = 0; i < dim; i++) {
+                origin[i] = new ErrorBound(this, ic.hull(x[i]), ic.numsToInterval(0, 0));
+            }
+            this.ic = ic;
+        }
+
+        public int getDim() {
+            return origin.length;
+        }
+
+        public ErrorBound getInp(int i) {
+            return origin[i];
+        }
+
+        public ErrorBound num(Rational x) {
+            SetInterval xi = ic.numsToInterval(x, x);
+            ExtendedRational x_rounded = ExtendedRationalContexts.mkNearest(valueSet).rnd(x);
+            SetInterval x_range;
+            if (x_rounded.isFinite()) {
+                x_range = ic.convexHull(xi, ic.numsToInterval(x_rounded, x_rounded));
+            } else if (x_rounded.signum() < 0) {
+                x_range = ic.numsToInterval(ExtendedRational.NEGATIVE_INFINITY, xi.sup());
+            } else {
+                x_range = ic.numsToInterval(xi.inf(), ExtendedRational.POSITIVE_INFINITY);
+            }
+            ExtendedRational err = exact.sub(x_rounded, x);
+            return new ErrorBound(this, x_range, ic.numsToInterval(err, err));
+        }
+        
+        private SetInterval rndErr(SetInterval range) {
+            return rndErr(range, HALF);
+        }
+
+        private SetInterval rndErr(SetInterval range, Rational ulps) {
+            ExtendedRational err = range.isCommonInterval() ? exact.mul(valueSet.ulp(range.mag()), ulps) : ExtendedRational.POSITIVE_INFINITY;
+            return ic.numsToInterval(exact.neg(err), err);
+        }
+
+        private void check(ErrorBound that) {
+            if (that.factory != this) {
+                throw new IllegalArgumentException();
+            }
+        }
+    }
+
+    public static Factory createFactory(SetIntervalContext ic, BinaryValueSet valueSet, SetInterval... x) {
+        return new Factory(ic, valueSet, x);
+    }
+
+    private ErrorBound(Factory factory, SetInterval range, SetInterval err) {
+        this.factory = factory;
+        this.range = range;
+        this.err = err;
+    }
+    
+    public SetInterval getRange() {
+        return range;
+    }
+    
+    public SetInterval getErr() {
+        return err;
+    }
+    
+    public SetInterval getCompensation() {
+        SetIntervalContext ic1 = SetIntervalContexts.getInfSup(factory.valueSet);
+        SetInterval compensation = ic1.neg(err);
+        for (;;) {
+            ErrorBound err1 = add(factory.num((Rational) compensation.inf()));
+            ErrorBound err2 = add(factory.num((Rational) compensation.sup()));
+            SetInterval newCompensation = ic1.convexHull(compensation,
+                    ic1.convexHull(ic1.neg(err1.getErr()), ic1.neg(err2.getErr())));
+            if (newCompensation.equals(compensation)) {
+                break;
+            } else {
+                compensation = newCompensation;
+            }
+        }
+        return compensation;
+    }
+    
+    public ErrorBound neg() {
+        SetIntervalContext ic = factory.ic;
+        return new ErrorBound(factory, ic.neg(range), ic.neg(err));
+    }
+
+    public ErrorBound add(ErrorBound y) {
+        factory.check(y);
+        SetIntervalContext ic = factory.ic;
+        SetInterval range = ic.add(this.range, y.range);
+        SetInterval gX = ic.numsToInterval(1, 1);
+        SetInterval gY = ic.numsToInterval(1, 1);
+        SetInterval err = ic.add(ic.mul(this.err, gX), ic.mul(y.err, gY));
+        SetInterval rndErr = factory.rndErr(range);
+        return new ErrorBound(factory, ic.add(range, rndErr), ic.add(err, rndErr));
+    }
+    
+    public ErrorBound sub(ErrorBound y) {
+        factory.check(y);
+        SetIntervalContext ic = factory.ic;
+        SetInterval range = ic.sub(this.range, y.range);
+        SetInterval gX = ic.numsToInterval(1, 1);
+        SetInterval gY = ic.numsToInterval(-1, -1);
+        SetInterval err = ic.add(ic.mul(this.err, gX), ic.mul(y.err, gY));
+        SetInterval rndErr = factory.rndErr(range);
+        return new ErrorBound(factory, ic.add(range, rndErr), ic.add(err, rndErr));
+    }
+    
+    public ErrorBound mul(ErrorBound y) {
+        factory.check(y);
+        SetIntervalContext ic = factory.ic;
+        SetInterval range = ic.mul(this.range, y.range);
+        SetInterval gX = y.range;
+        SetInterval gY = this.range;
+        SetInterval err = ic.add(ic.mul(this.err, gX), ic.mul(y.err, gY));
+        SetInterval rndErr = factory.rndErr(range);
+        return new ErrorBound(factory, ic.add(range, rndErr), ic.add(err, rndErr));
+    }
+    
+    public ErrorBound sqr() {
+        SetIntervalContext ic = factory.ic;
+        SetInterval range = ic.sqr(this.range);
+        SetInterval gX = ic.mul(ic.numsToInterval(2, 2), this.range);
+        SetInterval err = ic.mul(this.err, gX);
+        SetInterval rndErr = factory.rndErr(range);
+        return new ErrorBound(factory, ic.add(range, rndErr), ic.add(err, rndErr));
+    }
+    
+    public ErrorBound sin() {
+        SetIntervalContext ic = factory.ic;
+        SetInterval range = ic.sin(this.range);
+        SetInterval gX = ic.cos(this.range);
+        SetInterval err = ic.mul(this.err, gX);
+        SetInterval rndErr = factory.rndErr(range, Rational.one());
+        return new ErrorBound(factory, ic.add(range, rndErr), ic.add(err, rndErr));
+    }
+}

--- a/Global Optimization (New library)/src/IAOGO_err.java
+++ b/Global Optimization (New library)/src/IAOGO_err.java
@@ -1,0 +1,134 @@
+import net.java.jinterval.interval.set.SetInterval;
+import net.java.jinterval.interval.set.SetIntervalContext;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import net.java.jinterval.rational.BinaryValueSet;
+import net.java.jinterval.rational.Rational;
+
+public class IAOGO_err {
+    PriorityQueue<ListElem> wList = new PriorityQueue<ListElem>(new AssessmentComp()); //is used for storage objects of ListElem
+    private SetIntervalContext ic;
+    private double compensationInf, compensationSup;
+    private long boxCount;
+    private long maxQueueSize = 0;
+
+    private static String p(SetInterval s) {
+        return "[" + s.doubleInf() + "," + s.doubleSup() + "]";
+    }
+    
+    private void initConstants(SetIntervalContext ic, SetInterval[] box) {
+        this.ic = ic;
+        ErrorBound.Factory factory = ErrorBound.createFactory(ic, BinaryValueSet.BINARY64, box);
+        
+        ErrorBound c_1 = factory.num(Rational.valueOf(1));
+        ErrorBound c_2 = factory.num(Rational.valueOf(2));
+        ErrorBound a = factory.getInp(0);
+        ErrorBound b = factory.getInp(1);
+        ErrorBound thetaB = factory.getInp(2);
+        ErrorBound err = a.sqr()
+                .add(b.add(c_1).sqr())
+                .add(c_2.mul(a).mul(b.add(c_1)).mul(thetaB.sin()));
+        SetInterval compensation = err.getCompensation();
+        compensationInf = compensation.doubleInf();
+        compensationSup = compensation.doubleSup();
+        boxCount = 0;
+        maxQueueSize = 0;
+    }
+    
+    public SetInterval objectiveFunction(SetInterval[] origin) { // origin = [a b theta]
+        boxCount++;
+        maxQueueSize = Math.max(maxQueueSize, wList.size());
+        // returning value is a^2 + (b+1)^2 - 2*a * (b+1) * sin(theta)
+        //if you want to find max of function - just use ic.neg() to whole expression, and take off minus from result
+        double ai = origin[0].doubleInf();
+        double as = origin[0].doubleSup();
+        double bi = origin[1].doubleInf();
+        double bs = origin[1].doubleSup();
+        double thetai = origin[2].doubleInf();
+        double thetas = origin[2].doubleSup();
+        double bi1 = bi + 1;
+        double bs1 = bs + 1;
+        double inf = ai*ai + bi1*bi1 - 2*as*bs1*Math.sin(thetas) + compensationInf;
+        double sup = as*as + bs1*bs1 - 2*ai*bi1*Math.sin(thetai) + compensationSup;
+        return ic.numsToInterval(inf, sup);
+    }
+
+    public void IntFunc() {
+        SetInterval[] first = wList.peek().getData().clone();
+        SetInterval[] second = first.clone();
+        //we initialize two clones of box, which stores in leading element of the list
+        //next step - find the widest component of box
+        int j = 0;
+        double max = first[0].doubleWid();
+        for (int i = 1; i < first.length; i++)
+            if (first[i].doubleWid() > max) {
+                max = first[i].doubleWid();
+                j = i;
+            }
+        //now we bisect each clone by the widest component, first - from lower boundary to middle, second - from middle to upper boundary        
+        first[j] = ic.numsToInterval(first[j].doubleInf(),first[j].doubleMid());
+        second[j] = ic.numsToInterval(second[j].doubleMid(),second[j].doubleSup());
+        //here we create two elements of list with corresponding ranges of objective function and mins
+        ListElem firstel = new ListElem(first, objectiveFunction(first).doubleInf());
+        ListElem secondel = new ListElem(second, objectiveFunction(second).doubleInf());
+        //further - remove leading element
+        wList.poll();
+        //and add new two with automatic collation, provided by PriorityQueue collection
+        wList.add(firstel);
+        wList.add(secondel);
+    }
+
+    public void start(SetInterval[] box, double tolerance, SetIntervalContext ic) {
+        initConstants(ic, box); //define the SetIntervalContext for following computing
+        SetInterval intArea = objectiveFunction(box); //now we have defined range of objective function
+        double intwid = intArea.doubleWid(); //width of range will be used for stopping criterion
+        ListElem wrk = new ListElem(box,intArea.doubleInf());
+        //at this step we initialized new element of Our List, it's consist of domain of objective function and the min of range of objective function
+        wList.add(wrk);
+        // when new element adds to the list, it's automatically compare with other elements of list by second field (min), and sorts in ascending order
+        while (intwid >= tolerance) {
+            IntFunc(); // check IntFunc() for detailed description
+            intwid = objectiveFunction(wList.peek().getData()).doubleWid(); //here we take the min of leading element of the List
+        }
+//        System.out.println("boxCount=" + boxCount+ " maxQueueSize=" + maxQueueSize);
+    }
+}
+
+class AssessmentCompErr implements Comparator<ListElemErr> {
+    public int compare(ListElemErr el1, ListElemErr el2) {
+        return Double.valueOf(el1.getAssessment()).compareTo(el2.getAssessment());
+    }
+}
+
+class ListElemErr implements Comparable<ListElemErr> {
+
+    private SetInterval[] data; //here we store domain of objective function
+    private double assessment; //this field represents infumum of range of objective function for ListElem
+
+    ListElemErr() {
+        data = null;
+        assessment = 0;
+    }
+
+    ListElemErr(SetInterval[] data, double assessment) {
+        this.data = data;
+        this.assessment = assessment;
+    }
+
+    public double getAssessment() {
+        return assessment;
+    }
+    public void setAssessment(double assessment) {
+        this.assessment = assessment;
+    }
+    public SetInterval[] getData() {
+        return this.data;
+    }
+    public void setData(SetInterval[] data) {
+        this.data = data;
+    }
+    public int compareTo(ListElemErr el) { //at this place and at strings 58-62 we redefined comparator for comparison ListElem objects by "assessment" field
+        return Double.valueOf(this.assessment).compareTo(Double.valueOf(el.assessment));
+    }
+}

--- a/Global Optimization (New library)/src/Main_err.java
+++ b/Global Optimization (New library)/src/Main_err.java
@@ -1,0 +1,56 @@
+
+import net.java.jinterval.interval.set.SetInterval;
+import net.java.jinterval.interval.set.SetIntervalContext;
+import net.java.jinterval.interval.set.SetIntervalContexts;
+
+/**
+ *
+ */
+public class Main_err {
+
+    private static void test(String msg, SetIntervalContext ic, double... tolerances) {
+        System.out.println(msg);
+        for (double tolerance : tolerances) {
+            long startTime = System.currentTimeMillis();
+            SetInterval d = ic.numsToInterval(15.2, 34.8);
+            SetInterval X = ic.numsToInterval(100, 100);
+            SetInterval L = ic.numsToInterval(19.1, 55.2);
+            SetInterval theta = ic.numsToInterval(0, 1.18);
+            //Here we wanted to initialize interval box = [ a b theta]
+            //, where a = 2*L/d, b = 2*X/d
+            SetInterval box[] = {ic.div(ic.mul(ic.numsToInterval(2, 2), L), d), ic.div(ic.numsToInterval(200, 200), d), theta};
+            IAOGO_err algorithm = new IAOGO_err();
+            //Now we'll launch basic version of interval algorithm of global optimization for chosen objective function,
+            //interval box, tolerance and Context (ic)
+            algorithm.start(box, tolerance, ic);
+            long stopTime = System.currentTimeMillis();
+            System.out.println("tol=" + tolerance + " res=" + algorithm.wList.peek().getAssessment() + " time=" + (stopTime - startTime) / 1E3 + "s");
+        }
+    }
+
+    public static void main(String[] args) {
+        test("plain_err", SetIntervalContexts.getAccur64(), 1E-3, 1E-4, 1E-5, 1E-6, 1E-7);
+    }
+}
+/*
+plain_err
+tol=0.001 res=6.605350712420997 time=0.317s
+tol=1.0E-4 res=6.605631967925274 time=0.848s
+tol=1.0E-5 res=6.605658079647722 time=2.891s
+tol=1.0E-6 res=6.605660197332125 time=11.263s
+tol=1.0E-7 res=6.605660471995233 time=42.512s
+
+plain_err
+tol=0.001 res=6.605350712420997 time=0.308s
+tol=1.0E-4 res=6.605631967925274 time=0.849s
+tol=1.0E-5 res=6.605658079647722 time=2.834s
+tol=1.0E-6 res=6.605660197332125 time=11.614s
+tol=1.0E-7 res=6.605660471995233 time=57.177s
+
+plain_err
+tol=0.001 res=6.605350712420997 time=0.306s
+tol=1.0E-4 res=6.605631967925274 time=0.828s
+tol=1.0E-5 res=6.605658079647722 time=2.932s
+tol=1.0E-6 res=6.605660197332125 time=10.942s
+tol=1.0E-7 res=6.605660471995233 time=39.985s
+ */

--- a/Global Optimization (New library)/src/TestErrorBound.java
+++ b/Global Optimization (New library)/src/TestErrorBound.java
@@ -1,0 +1,49 @@
+
+import net.java.jinterval.interval.set.SetInterval;
+import net.java.jinterval.interval.set.SetIntervalContext;
+import net.java.jinterval.interval.set.SetIntervalContexts;
+import net.java.jinterval.rational.BinaryValueSet;
+import net.java.jinterval.rational.Rational;
+
+/**
+ *
+ */
+public class TestErrorBound {
+
+    private static String p(SetInterval s) {
+        return "[" + s.doubleInf() + "," + s.doubleSup() + "]";
+    }
+    
+    private static void test(String msg, BinaryValueSet valueSet) {
+        SetIntervalContext ic = SetIntervalContexts.getInfSup(BinaryValueSet.BINARY128);
+        SetInterval d = ic.numsToInterval(15.2, 34.8);
+        SetInterval X = ic.numsToInterval(100, 100);
+        SetInterval L = ic.numsToInterval(19.1, 55.2);
+        SetInterval theta = ic.numsToInterval(0, 1.18);
+        //Here we wanted to initialize interval box = [ a b theta]
+        //, where a = 2*L/d, b = 2*X/d
+        SetInterval box[] = {ic.div(ic.mul(ic.numsToInterval(2, 2), L), d), ic.div(ic.numsToInterval(200, 200), d), theta};
+        ErrorBound.Factory factory = ErrorBound.createFactory(ic, valueSet, box);
+        
+        ErrorBound c_1 = factory.num(Rational.valueOf(1));
+        ErrorBound c_2 = factory.num(Rational.valueOf(2));
+        ErrorBound a = factory.getInp(0);
+        ErrorBound b = factory.getInp(1);
+        ErrorBound thetaB = factory.getInp(2);
+        ErrorBound errB = a.sqr()
+                .add(b.add(c_1).sqr())
+                .add(c_2.mul(a).mul(b.add(c_1)).mul(thetaB.sin()));
+        SetInterval compensation = errB.getCompensation();
+        System.out.println(msg + " range=" + p(errB.getRange()) + " err=" + p(errB.getErr())
+                + " comp=" + p(compensation));
+    }
+
+    public static void main(String[] args) {
+        test("b16", BinaryValueSet.BINARY16);
+        test("b32", BinaryValueSet.BINARY32);
+        test("b64", BinaryValueSet.BINARY64);
+        test("b80", BinaryValueSet.BINARY80);
+        test("b128", BinaryValueSet.BINARY128);
+    }
+
+}


### PR DESCRIPTION
Попробовал такой подход:
1) На большом брусе один раз доказуемо вычисляем накопленную ошибку округления при plain вычислениях в этом брусе. Вычисляем числа, которые могут компенсировать ошибку и превратить её в даказанную.
Затем многократно вычисляем на подбрусах с компенсацией.
2) Вручную перевёл вычисления в последовательность операций над примитивным double .Надеюсь, что в будущем этот код можно будет генерировать автоматически.
